### PR TITLE
Add navigation window after authentication

### DIFF
--- a/FaceRecognitionClient/MVVMStructures/ViewModels/NavigationWindow/NavigationWindowViewModel.cs
+++ b/FaceRecognitionClient/MVVMStructures/ViewModels/NavigationWindow/NavigationWindowViewModel.cs
@@ -1,0 +1,28 @@
+using FaceRecognitionClient.Commands;
+using FaceRecognitionClient.StateMachine;
+
+namespace FaceRecognitionClient.MVVMStructures.ViewModels.NavigationWindow
+{
+    /// <summary>
+    /// View model for the navigation window displayed after authentication.
+    /// Provides commands to switch to the major application screens.
+    /// </summary>
+    public class NavigationWindowViewModel : BaseViewModel, IStateNotifier
+    {
+        public event Action<ApplicationTrigger> OnTriggerOccurred;
+
+        public RelayCommand OpenFaceRecognitionCommand { get; }
+        public RelayCommand OpenGalleryCommand { get; }
+        public RelayCommand OpenAttendanceCommand { get; }
+
+        public NavigationWindowViewModel()
+        {
+            OpenFaceRecognitionCommand = new RelayCommand(_ =>
+                OnTriggerOccurred?.Invoke(ApplicationTrigger.FaceRecognitionRequested));
+            OpenGalleryCommand = new RelayCommand(_ =>
+                OnTriggerOccurred?.Invoke(ApplicationTrigger.GalleryRequested));
+            OpenAttendanceCommand = new RelayCommand(_ =>
+                OnTriggerOccurred?.Invoke(ApplicationTrigger.AttendanceRequested));
+        }
+    }
+}

--- a/FaceRecognitionClient/MVVMStructures/Views/NavigationWindow/NavigationWindow.xaml
+++ b/FaceRecognitionClient/MVVMStructures/Views/NavigationWindow/NavigationWindow.xaml
@@ -1,0 +1,30 @@
+<Window x:Class="FaceRecognitionClient.Views.NavigationWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Navigation" Height="800" Width="1200"
+        ResizeMode="NoResize"
+        WindowStartupLocation="CenterScreen"
+        Background="White">
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+
+        <Button Grid.Column="0" Content="Face Recognition"
+                Command="{Binding OpenFaceRecognitionCommand}"
+                Width="200" Height="200" HorizontalAlignment="Center" VerticalAlignment="Center"
+                Style="{StaticResource ModernButton}"/>
+
+        <Button Grid.Column="1" Content="Gallery"
+                Command="{Binding OpenGalleryCommand}"
+                Width="200" Height="200" HorizontalAlignment="Center" VerticalAlignment="Center"
+                Style="{StaticResource ModernButton}"/>
+
+        <Button Grid.Column="2" Content="Attendance"
+                Command="{Binding OpenAttendanceCommand}"
+                Width="200" Height="200" HorizontalAlignment="Center" VerticalAlignment="Center"
+                Style="{StaticResource ModernButton}"/>
+    </Grid>
+</Window>

--- a/FaceRecognitionClient/MVVMStructures/Views/NavigationWindow/NavigationWindow.xaml.cs
+++ b/FaceRecognitionClient/MVVMStructures/Views/NavigationWindow/NavigationWindow.xaml.cs
@@ -1,0 +1,15 @@
+using System.Windows;
+
+namespace FaceRecognitionClient.Views
+{
+    /// <summary>
+    /// Interaction logic for NavigationWindow.xaml
+    /// </summary>
+    public partial class NavigationWindow : Window
+    {
+        public NavigationWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/FaceRecognitionClient/StateMachine/ApplicationState.cs
+++ b/FaceRecognitionClient/StateMachine/ApplicationState.cs
@@ -14,6 +14,7 @@
         EmailVerificationWindow,
         GalleryWindow,
         ForgotPasswordWindow,
-        AttendanceWindow
+        AttendanceWindow,
+        NavigationWindow
     }
 }


### PR DESCRIPTION
## Summary
- introduce `NavigationWindow` view and `NavigationWindowViewModel`
- define `NavigationWindow` state in the state machine
- show navigation hub after email verification or developer login
- connect buttons to switch to Face Recognition, Gallery or Attendance windows

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68484cb0a634832cb015e486b4c3e76e