### PR TITLE
Add back navigation support across views

### DIFF
--- a/FaceRecognitionClient/MVVMStructures/ViewModels/Attendance/GeneralAttendanceViewModel.cs
+++ b/FaceRecognitionClient/MVVMStructures/ViewModels/Attendance/GeneralAttendanceViewModel.cs
@@ -4,6 +4,7 @@ using FaceRecognitionClient.Commands;
 using FaceRecognitionClient.InternalDataModels;
 using FaceRecognitionClient.MVVMStructures.Models.Attendance;
 using FaceRecognitionClient.MVVMStructures.ViewModels.PersonProfile;
+using FaceRecognitionClient.StateMachine;
 using System.CodeDom;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -11,7 +12,7 @@ using System.Windows.Data;
 
 namespace FaceRecognitionClient.MVVMStructures.ViewModels.Attendance
 {
-    public class GeneralAttendanceViewModel : BaseViewModel, IDetailNotifier<AdvancedPersonDataWithImage>
+    public class GeneralAttendanceViewModel : BaseViewModel, IDetailNotifier<AdvancedPersonDataWithImage>, IStateNotifier
     {
         private readonly INetworkFacade m_Network;
         private readonly Mapper m_Mapper;
@@ -37,6 +38,10 @@ namespace FaceRecognitionClient.MVVMStructures.ViewModels.Attendance
 
         public event Action<AdvancedPersonDataWithImage> OnDetailRequested;
 
+        public event Action<ApplicationTrigger> OnTriggerOccurred;
+
+        public RelayCommand BackCommand { get; }
+
         public AttendanceRecord SelectedAttendanceRecord
         {
             get => m_SelectedAttendanceRecord;
@@ -58,6 +63,7 @@ namespace FaceRecognitionClient.MVVMStructures.ViewModels.Attendance
 
             RefreshCommand = new AsyncRelayCommand(_ => LoadAsync());
             OpenProfileCommand = new AsyncRelayCommand(_ => OpenProfileAsync());
+            BackCommand = new RelayCommand(_ => OnTriggerOccurred?.Invoke(ApplicationTrigger.NavigationRequested));
         }
 
         public async Task LoadAsync()

--- a/FaceRecognitionClient/MVVMStructures/ViewModels/FaceRecognition/FaceRecognitionViewModel.cs
+++ b/FaceRecognitionClient/MVVMStructures/ViewModels/FaceRecognition/FaceRecognitionViewModel.cs
@@ -23,11 +23,9 @@ namespace FaceRecognitionClient.MVVMStructures.ViewModels.FaceRecognition
 
         public RelayCommand OpenCameraViewCommand { get; }
 
-        public RelayCommand OpenAttendanceCommand { get; }
-
         public AsyncRelayCommand SendImageCommand { get; }
 
-        public RelayCommand OpenGalleryCommand { get; }
+        public RelayCommand BackCommand { get; }
 
         public ObservableCollection<FaceRecordViewModel> RecognizedPersons { get; } = new();
 
@@ -51,8 +49,7 @@ namespace FaceRecognitionClient.MVVMStructures.ViewModels.FaceRecognition
             UploadImageCommand = new AsyncRelayCommand(_ => OnUploadImage());
             OpenCameraViewCommand = new RelayCommand(_ => ChangeToCameraCaptureView());
             SendImageCommand = new AsyncRelayCommand(_ => OnSendImageForRecognitionAsync(), _ => ImageSource != null);
-            OpenGalleryCommand = new RelayCommand(_ => OnTriggerOccurred?.Invoke(ApplicationTrigger.GalleryRequested));
-            OpenAttendanceCommand = new RelayCommand(_ => OnTriggerOccurred?.Invoke(ApplicationTrigger.AttendanceRequested));
+            BackCommand = new RelayCommand(_ => OnTriggerOccurred?.Invoke(ApplicationTrigger.NavigationRequested));
         }
 
         // Loads the photo that was taken by the camera into this view

--- a/FaceRecognitionClient/MVVMStructures/ViewModels/Gallery/GalleryViewModel.cs
+++ b/FaceRecognitionClient/MVVMStructures/ViewModels/Gallery/GalleryViewModel.cs
@@ -29,8 +29,8 @@ namespace FaceRecognitionClient.MVVMStructures.ViewModels.Gallery
             // Command to reload gallery images
             RefreshCommand = new AsyncRelayCommand(_ => LoadImagesAsync());
 
-            // Navigate back to face recognition screen
-            BackCommand = new RelayCommand(_ => OnTriggerOccurred?.Invoke(ApplicationTrigger.FaceRecognitionRequested));
+            // Navigate back to the main navigation window
+            BackCommand = new RelayCommand(_ => OnTriggerOccurred?.Invoke(ApplicationTrigger.NavigationRequested));
 
         }
 

--- a/FaceRecognitionClient/MVVMStructures/Views/Attendance/GeneralAttendanceView.xaml
+++ b/FaceRecognitionClient/MVVMStructures/Views/Attendance/GeneralAttendanceView.xaml
@@ -22,36 +22,45 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <!-- Controls: Refresh + Sort Toggle -->
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,0,0,10" Grid.Row="0" >
-            <Button Content="Refresh"
-                    Command="{Binding RefreshCommand}"
-                    Padding="16,6"
-                    Background="#6A5ACD"
-                    Foreground="White"
-                    FontWeight="Bold"
-                    BorderThickness="0"
-                    Cursor="Hand"
-                    Margin="0,0,10,0"
-                    Width="100"
-                    Height="32"
-                    VerticalAlignment="Center"
-                    HorizontalAlignment="Right"
-                    />
-        
-            <ToggleButton Content="{Binding SortDescending, Converter={StaticResource BoolToSortLabelConverter}}"
-                          IsChecked="{Binding SortDescending}"
-                          Padding="12,4"
-                          Background="#6A5ACD"
-                          Foreground="White"
-                          FontWeight="Bold"
-                          BorderThickness="0"
-                          Cursor="Hand"
-                          Width="120"
-                          Height="32"
-                          VerticalAlignment="Center"
-                          /> 
-        </StackPanel>
+        <!-- Controls: Back, Refresh and Sort Toggle -->
+        <Grid Grid.Row="0" Margin="0,0,0,10">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <Button Content="Back"
+                    Command="{Binding BackCommand}"
+                    Style="{StaticResource ModernButton}"
+                    Width="80" Margin="0,0,10,0"/>
+
+            <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button Content="Refresh"
+                        Command="{Binding RefreshCommand}"
+                        Padding="16,6"
+                        Background="#6A5ACD"
+                        Foreground="White"
+                        FontWeight="Bold"
+                        BorderThickness="0"
+                        Cursor="Hand"
+                        Margin="0,0,10,0"
+                        Width="100"
+                        Height="32"
+                        VerticalAlignment="Center"/>
+
+                <ToggleButton Content="{Binding SortDescending, Converter={StaticResource BoolToSortLabelConverter}}"
+                              IsChecked="{Binding SortDescending}"
+                              Padding="12,4"
+                              Background="#6A5ACD"
+                              Foreground="White"
+                              FontWeight="Bold"
+                              BorderThickness="0"
+                              Cursor="Hand"
+                              Width="120"
+                              Height="32"
+                              VerticalAlignment="Center"/>
+            </StackPanel>
+        </Grid>
 
         <!-- Rounded DataGrid -->
         <Border Grid.Row="1"

--- a/FaceRecognitionClient/MVVMStructures/Views/FaceRecognition/FaceRecoginitionWindow.xaml
+++ b/FaceRecognitionClient/MVVMStructures/Views/FaceRecognition/FaceRecoginitionWindow.xaml
@@ -39,12 +39,18 @@
             <ColumnDefinition Width="400" />
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
+        <!-- Back button -->
+        <Button Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="0" Content="Back"
+                Command="{Binding BackCommand}"
+                Style="{StaticResource ModernButton}" Width="80" HorizontalAlignment="Left" Margin="10"/>
+
         <!-- Left side: Image -->
-        <Border Grid.Column="0" Grid.Row="0" Margin="10" CornerRadius="10" BorderBrush="#CCC" BorderThickness="1">
+        <Border Grid.Column="0" Grid.Row="1" Margin="10" CornerRadius="10" BorderBrush="#CCC" BorderThickness="1">
             <Image Source="{Binding ImageSource}"
                    Height="600"
                    Stretch="Uniform"
@@ -52,7 +58,7 @@
         </Border>
 
         <!-- Buttons underneath the image -->
-        <StackPanel Grid.Column="0" Grid.Row="1"
+        <StackPanel Grid.Column="0" Grid.Row="2"
                     Orientation="Horizontal"
                     HorizontalAlignment="Center"
                     Margin="10">
@@ -68,18 +74,10 @@
                     Command="{Binding SendImageCommand}">
                 <TextBlock Text="📤"/>
             </Button>
-            <Button Style="{StaticResource CircleIconButton}"
-                    Command="{Binding OpenGalleryCommand}">
-                <TextBlock Text="🖼️"/>
-            </Button>
-            <Button Style="{StaticResource CircleIconButton}"
-                    Command="{Binding OpenAttendanceCommand}">
-                <TextBlock Text="📅"/>
-            </Button>
         </StackPanel>
 
         <!-- Right side: Recognized persons card panel -->
-        <Border Grid.Column="1" Grid.RowSpan="2"
+        <Border Grid.Column="1" Grid.Row="0" Grid.RowSpan="3"
                 Background="White"
                 Padding="10"
                 CornerRadius="10">

--- a/FaceRecognitionClient/StateMachine/ApplicationTrigger.cs
+++ b/FaceRecognitionClient/StateMachine/ApplicationTrigger.cs
@@ -23,6 +23,10 @@
         ForgotPasswordRequested,
         PasswordResetSuccessful,
         AttendanceRequested,
+        /// <summary>
+        /// Request to return to the main navigation window.
+        /// </summary>
+        NavigationRequested,
         UserDisconnected,
         /// <summary>
         /// User has requested to log out of the application.

--- a/FaceRecognitionClient/WindowService.cs
+++ b/FaceRecognitionClient/WindowService.cs
@@ -91,7 +91,8 @@ namespace LogInClient
                 m_GalleryViewModel,
                 m_ForgotPasswordViewModel,
                 m_NavigationWindowViewModel,
-                m_DisconnectedViewModel
+                m_DisconnectedViewModel,
+                m_GeneralAttendanceViewModel
             });
 
             m_DetailNotifiers.AddRange(new IDetailNotifier<AdvancedPersonDataWithImage>[]
@@ -151,11 +152,14 @@ namespace LogInClient
             stateMachine.AddTransition(ApplicationState.FaceRecognitionWindow, ApplicationTrigger.CameraCaptureRequested, ApplicationState.CameraCaptureWindow);
             stateMachine.AddTransition(ApplicationState.FaceRecognitionWindow, ApplicationTrigger.GalleryRequested, ApplicationState.GalleryWindow);
             stateMachine.AddTransition(ApplicationState.FaceRecognitionWindow, ApplicationTrigger.AttendanceRequested, ApplicationState.AttendanceWindow);
+            stateMachine.AddTransition(ApplicationState.FaceRecognitionWindow, ApplicationTrigger.NavigationRequested, ApplicationState.NavigationWindow);
             stateMachine.AddTransition(ApplicationState.NavigationWindow, ApplicationTrigger.FaceRecognitionRequested, ApplicationState.FaceRecognitionWindow);
             stateMachine.AddTransition(ApplicationState.NavigationWindow, ApplicationTrigger.GalleryRequested, ApplicationState.GalleryWindow);
             stateMachine.AddTransition(ApplicationState.NavigationWindow, ApplicationTrigger.AttendanceRequested, ApplicationState.AttendanceWindow);
             stateMachine.AddTransition(ApplicationState.GalleryWindow, ApplicationTrigger.FaceRecognitionRequested, ApplicationState.FaceRecognitionWindow);
+            stateMachine.AddTransition(ApplicationState.GalleryWindow, ApplicationTrigger.NavigationRequested, ApplicationState.NavigationWindow);
             stateMachine.AddTransition(ApplicationState.CameraCaptureWindow, ApplicationTrigger.FaceRecognitionRequested, ApplicationState.FaceRecognitionWindow);
+            stateMachine.AddTransition(ApplicationState.AttendanceWindow, ApplicationTrigger.NavigationRequested, ApplicationState.NavigationWindow);
             stateMachine.AddTransition(ApplicationState.LogInWindow, ApplicationTrigger.LogInFailed, ApplicationState.LogInWindow);
             stateMachine.AddTransition(ApplicationState.ForgotPasswordWindow, ApplicationTrigger.LogInRequested, ApplicationState.LogInWindow);
             stateMachine.AddTransition(ApplicationState.LogInWindow, ApplicationTrigger.ForgotPasswordRequested, ApplicationState.ForgotPasswordWindow);


### PR DESCRIPTION
## Summary
- add `NavigationRequested` trigger for returning to navigation window
- wire back commands in face recognition, attendance and gallery view models
- show Back buttons in FaceRecognition and Attendance windows
- update state machine transitions and notifier registration
- remove gallery and attendance controls from face recognition view

## Testing
- `dotnet build FaceRecognitionClient/FaceRecognitionClient.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e1145e34832cab9c4baef5fb7668