### PR TITLE
Add attendance export feature

### DIFF
--- a/FaceRecognitionClient/MVVMStructures/ViewModels/Attendance/GeneralAttendanceViewModel.cs
+++ b/FaceRecognitionClient/MVVMStructures/ViewModels/Attendance/GeneralAttendanceViewModel.cs
@@ -1,3 +1,7 @@
+using System.Linq;
+using Microsoft.Win32;
+using System.IO;
+using FaceRecognitionClient.Services.AttendanceExportService;
 ﻿using DataProtocols.GalleryMessages.Models;
 using DataProtocols.RetrievingPersonDataMessages;
 using FaceRecognitionClient.Commands;
@@ -24,6 +28,7 @@ namespace FaceRecognitionClient.MVVMStructures.ViewModels.Attendance
         public ICollectionView AttendanceView { get; }
         public AsyncRelayCommand RefreshCommand { get; }
         public AsyncRelayCommand OpenProfileCommand { get; }
+        public AsyncRelayCommand ExportCommand { get; }
 
         public bool SortDescending
         {
@@ -63,6 +68,7 @@ namespace FaceRecognitionClient.MVVMStructures.ViewModels.Attendance
 
             RefreshCommand = new AsyncRelayCommand(_ => LoadAsync());
             OpenProfileCommand = new AsyncRelayCommand(_ => OpenProfileAsync());
+            ExportCommand = new AsyncRelayCommand(_ => ExportAsync());
             BackCommand = new RelayCommand(_ => OnTriggerOccurred?.Invoke(ApplicationTrigger.NavigationRequested));
         }
 
@@ -118,6 +124,36 @@ namespace FaceRecognitionClient.MVVMStructures.ViewModels.Attendance
             {
                 ClientLogger.ClientLogger.LogException(ex, $"Exception opening person profile window for ID {SelectedAttendanceRecord?.Id}.");
             }
+        }
+
+        private async Task ExportAsync()
+        {
+            var dialog = new OpenFileDialog
+            {
+                CheckFileExists = false,
+                CheckPathExists = true,
+                ValidateNames = false,
+                Filter = "Text files (*.txt)|*.txt|All files (*.*)|*.*",
+                FileName = "Select folder or file"
+            };
+
+            if (dialog.ShowDialog() != true)
+                return;
+
+            var path = dialog.FileName;
+            if (Directory.Exists(path))
+            {
+                var fileName = $"attendance_{DateTime.Now:yyyyMMdd_HHmmss}.txt";
+                path = Path.Combine(path, fileName);
+            }
+            else if (string.IsNullOrEmpty(Path.GetExtension(path)))
+            {
+                path += ".txt";
+            }
+
+            var exporter = new AttendanceExportService();
+            var records = AttendanceView.Cast<AttendanceRecord>().ToList();
+            await exporter.ExportAsync(records, path);
         }
 
         private void OnOpenPersonProfile(AdvancedPersonDataWithImage advancedPersonData) => OnDetailRequested?.Invoke(advancedPersonData);

--- a/FaceRecognitionClient/MVVMStructures/ViewModels/PersonProfile/AttendanceRecordsViewModel.cs
+++ b/FaceRecognitionClient/MVVMStructures/ViewModels/PersonProfile/AttendanceRecordsViewModel.cs
@@ -1,3 +1,7 @@
+using System.Linq;
+using Microsoft.Win32;
+using System.IO;
+using FaceRecognitionClient.Services.AttendanceExportService;
 ﻿using FaceRecognitionClient.Commands;
 using FaceRecognitionClient.InternalDataModels;
 using FaceRecognitionClient.MVVMStructures.Models.PersonProfile;
@@ -13,6 +17,7 @@ namespace FaceRecognitionClient.MVVMStructures.ViewModels.PersonProfile
         public ObservableCollection<AttendanceRecord> AttendanceRecords { get; } = new();
 
         public AsyncRelayCommand RefreshCommand { get; }
+        public AsyncRelayCommand ExportCommand { get; }
 
         public AttendanceRecordsViewModel(INetworkFacade network, Mapper mapper, AdvancedPersonData person)
         {
@@ -20,6 +25,7 @@ namespace FaceRecognitionClient.MVVMStructures.ViewModels.PersonProfile
             m_Person = person;
 
             RefreshCommand = new AsyncRelayCommand(_ => LoadAsync());
+            ExportCommand = new AsyncRelayCommand(_ => ExportAsync());
         }
 
         public async Task LoadAsync()
@@ -36,6 +42,35 @@ namespace FaceRecognitionClient.MVVMStructures.ViewModels.PersonProfile
             {
                 ClientLogger.ClientLogger.LogException(ex, "Failed to load attendance in AttendanceRecordsViewModel.");
             }
+        private async Task ExportAsync()
+        {
+            var dialog = new OpenFileDialog
+            {
+                CheckFileExists = false,
+                CheckPathExists = true,
+                ValidateNames = false,
+                Filter = "Text files (*.txt)|*.txt|All files (*.*)|*.*",
+                FileName = "Select folder or file"
+            };
+
+            if (dialog.ShowDialog() != true)
+                return;
+
+            var path = dialog.FileName;
+            if (Directory.Exists(path))
+            {
+                var fileName = $"attendance_{DateTime.Now:yyyyMMdd_HHmmss}.txt";
+                path = Path.Combine(path, fileName);
+            }
+            else if (string.IsNullOrEmpty(Path.GetExtension(path)))
+            {
+                path += ".txt";
+            }
+
+            var exporter = new AttendanceExportService();
+            var records = AttendanceRecords.Cast<AttendanceRecord>().ToList();
+            await exporter.ExportAsync(records, path);
         }
+
     }
 }

--- a/FaceRecognitionClient/MVVMStructures/Views/Attendance/GeneralAttendanceView.xaml
+++ b/FaceRecognitionClient/MVVMStructures/Views/Attendance/GeneralAttendanceView.xaml
@@ -47,6 +47,18 @@
                         Width="100"
                         Height="32"
                         VerticalAlignment="Center"/>
+                <Button Content="Export"
+                        Command="{Binding ExportCommand}"
+                        Padding="16,6"
+                        Background="#6A5ACD"
+                        Foreground="White"
+                        FontWeight="Bold"
+                        BorderThickness="0"
+                        Cursor="Hand"
+                        Margin="0,0,10,0"
+                        Width="100"
+                        Height="32"
+                        VerticalAlignment="Center"/>
 
                 <ToggleButton Content="{Binding SortDescending, Converter={StaticResource BoolToSortLabelConverter}}"
                               IsChecked="{Binding SortDescending}"

--- a/FaceRecognitionClient/MVVMStructures/Views/PersonProfile/AttendanceView.xaml
+++ b/FaceRecognitionClient/MVVMStructures/Views/PersonProfile/AttendanceView.xaml
@@ -20,6 +20,17 @@
                     FontWeight="SemiBold"
                     BorderThickness="0"
                     Cursor="Hand" />
+            <Button Content="Export"
+                    Command="{Binding ExportCommand}"
+                    Width="100"
+                    Height="32"
+                    Margin="0,0,0,10"
+                    HorizontalAlignment="Left"
+                    Background="#6A5ACD"
+                    Foreground="White"
+                    FontWeight="SemiBold"
+                    BorderThickness="0"
+                    Cursor="Hand" />
 
             <Border Background="White"
                     CornerRadius="10"

--- a/FaceRecognitionClient/Services/AttendanceExportService/AttendanceExportService.cs
+++ b/FaceRecognitionClient/Services/AttendanceExportService/AttendanceExportService.cs
@@ -1,0 +1,37 @@
+using FaceRecognitionClient.ClientLogger;
+using System.IO;
+using FaceRecognitionClient.MVVMStructures.ViewModels.PersonProfile;
+using System.Text;
+
+namespace FaceRecognitionClient.Services.AttendanceExportService
+{
+    public class AttendanceExportService
+    {
+        public Task ExportAsync(IEnumerable<AttendanceRecord> records, string filePath)
+        {
+            return Task.Run(() =>
+            {
+                try
+                {
+                    var directory = Path.GetDirectoryName(filePath);
+                    if (!string.IsNullOrEmpty(directory))
+                    {
+                        Directory.CreateDirectory(directory);
+                    }
+
+                    var sb = new StringBuilder();
+                    foreach (var record in records)
+                    {
+                        sb.AppendLine($"{record.FirstName}\t{record.LastName}\t{record.GovernmentId}\t{record.AttendanceTime:dd/MM/yyyy HH:mm}");
+                    }
+
+                    File.WriteAllText(filePath, sb.ToString());
+                }
+                catch (Exception ex)
+                {
+                    ClientLogger.ClientLogger.LogException(ex, "Failed to export attendance records");
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `AttendanceExportService` for writing attendance to text files
- support exporting attendance in GeneralAttendanceViewModel
- support exporting single person attendance in AttendanceRecordsViewModel
- add Export buttons in attendance views

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849eec0bcc8832cb36fce266c96f269